### PR TITLE
Changes Image Load Location for Github Pages

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -34,7 +34,8 @@ const isInput = bookDetails.querySelectorAll('.set-status input');
 
 const initBook = () => {
   const newBook = new Book('The Hobbit', 'J.R.R. Tolkien', '293', 'read');
-  newBook.setCover('../assets/thehobbit.jpg');
+  // newBook.setCover('../assets/thehobbit.jpg');
+  newBook.setCover(`${window.location.origin}/assets/thehobbit.jpg`);
   newBook.setCurrentPages(293);
 
   myListBook.push(newBook);
@@ -49,7 +50,8 @@ function Book (title, author, pages, status) {
   this.pages = pages;
   this.status = status;
   this.currentPages = 0;
-  this.cover = '../assets/no-preview.jpg';
+  // this.cover = '../assets/no-preview.jpg';
+  this.cover = `${window.location.origin}/assets/no-preview.jpg`;
 }
 
 Book.prototype.setCurrentPages = function(currentPages) {


### PR DESCRIPTION
changing image location to first book and no cover before example:
this.cover = '../assets/no-preview.jpg';

to
  this.cover = `${window.location.origin}/assets/no-preview.jpg`;

because github pages load from root not from current files location which is script.js inside js folder